### PR TITLE
feature/add rubocop rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,12 +19,10 @@ yarn-error.log
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
-
 .env
 
 # Emacs droppings
 *~
-
 *.gem
 
 # Mac OS noise

--- a/Dutchie-Style.gemspec
+++ b/Dutchie-Style.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.86.0"
+  spec.add_dependency "rubocop-rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    Dutchie-Style (1.0.1)
+    Dutchie-Style (1.0.2)
       rubocop (~> 0.86.0)
+      rubocop-rspec
 
 GEM
   remote: https://rubygems.org/
@@ -40,6 +41,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.0.3)
       parser (>= 2.7.0.1)
+    rubocop-rspec (1.38.1)
+      rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     unicode-display_width (1.7.0)
 

--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ It is available as a rubygem as well as an NPM package.
 Includes:
 
 * RuboCop Config
+* RuboCop Rspec Config
 * Eslint Config
 * Prettier Config

--- a/default.yml
+++ b/default.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-rspec
+
 AllCops:
   TargetRubyVersion: 2.6
   EnabledByDefault: true

--- a/default.yml
+++ b/default.yml
@@ -8,7 +8,6 @@ AllCops:
     - 'vendor/**/*'
     - 'config/**/*'
     - 'docs/**/*'
-    - 'spec/**/*'
     - 'app/channels/**/*'
     - 'script/**/*'
     - 'lib/assets/**/*'


### PR DESCRIPTION
Add https://github.com/rubocop-hq/rubocop-rspec to our ruby projects.

Once this has been merged in, I can add `rubocop --require rubocop-rspec --only RSpec/Focus` to our CI setup to detect `focus` in our projects to trigger a CI failure for only `focus` in specs at this time.