### PR TITLE
Add rubocop-rails. Should still work with non-rails ruby apps.

### DIFF
--- a/Dutchie-Style.gemspec
+++ b/Dutchie-Style.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rubocop", "~> 0.86.0"
   spec.add_dependency "rubocop-rspec"
+  spec.add_dependency "rubocop-rails"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 0.86"
+gem "rubocop-rails", "~> 2.6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,30 @@
 PATH
   remote: .
   specs:
-    Dutchie-Style (1.0.2)
+    Dutchie-Style (1.0.3)
       rubocop (~> 0.86.0)
+      rubocop-rails
       rubocop-rspec
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.3.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.1)
+    concurrent-ruby (1.1.7)
     diff-lcs (1.4.2)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.2)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
+    rack (2.2.3)
     rainbow (3.0.0)
     rake (12.3.3)
     regexp_parser (1.7.1)
@@ -41,10 +53,18 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.0.3)
       parser (>= 2.7.0.1)
-    rubocop-rspec (1.38.1)
+    rubocop-rails (2.6.0)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.82.0)
+    rubocop-rspec (1.41.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
@@ -54,6 +74,7 @@ DEPENDENCIES
   rake (~> 12.0)
   rspec (~> 3.0)
   rubocop (~> 0.86)
+  rubocop-rails (~> 2.6.0)
 
 BUNDLED WITH
    2.1.4

--- a/default.yml
+++ b/default.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-rspec
+  - rubocop-rails
 
 AllCops:
   TargetRubyVersion: 2.6
@@ -219,3 +220,13 @@ Naming/BinaryOperatorParameterName:
 
 Lint/ConstantResolution:
   Enabled: false
+
+
+# Rails
+Rails/SaveBang:
+  Enabled: false
+
+Rails/FindBy:
+  Enabled: true
+  Include:
+    - app/**/*.rb


### PR DESCRIPTION
Include the `rubocop-rails` gem.  This works with MenuConnector as well, it will start warning on issues related to ActiveSupport (`blank?` vs `present?`, `Time.now` etc) in that project.