### PR TITLE
style: Update some style guidelines

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -46,6 +46,12 @@ Layout/MultilineOperationIndentation:
 Lint/SuppressedException:
   Enabled: false
 
+Layout/SpaceInsideBlockBraces:
+  # The space here provides no real gain in readability while consuming
+  # horizontal space that could be used for a better parameter name.
+  # Also {| differentiates better from a hash than { | does.
+  SpaceBeforeBlockParameters: false
+
 # No trailing space differentiates better from the block:
 # foo} means hash, foo } means block.
 Layout/SpaceInsideHashLiteralBraces:
@@ -101,12 +107,15 @@ Style/StringLiterals:
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
 
+# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashEachMethods
 Style/HashEachMethods:
-  Enabled: false
+  Enabled: true
 
+# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashTransformKeys
 Style/HashTransformKeys:
   Enabled: false
 
+# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashTransformValues
 Style/HashTransformValues:
   Enabled: false
 

--- a/default.yml
+++ b/default.yml
@@ -46,16 +46,14 @@ Layout/MultilineOperationIndentation:
 Lint/SuppressedException:
   Enabled: false
 
-Layout/SpaceInsideBlockBraces:
-  # The space here provides no real gain in readability while consuming
-  # horizontal space that could be used for a better parameter name.
-  # Also {| differentiates better from a hash than { | does.
-  SpaceBeforeBlockParameters: false
-
 # No trailing space differentiates better from the block:
 # foo} means hash, foo } means block.
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+
+# Exclude RSpec
+Metrics/BlockLength:
+  ExcludedMethods: ['describe', 'context']
 
 # Too short methods lead to extraction of single-use methods, which can make
 # the code easier to read (by naming things), but can also clutter the class
@@ -203,10 +201,10 @@ Style/MethodDefParentheses:
 Lint/ShadowingOuterLocalVariable:
   Enabled: false
 
-# There are valid cases, for example debugging Cucumber steps,
-# also they'll fail CI anyway
+# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/Debugger
+# Show linting errors on debugger/binding.pry even in development
 Lint/Debugger:
-  Enabled: false
+  Enabled: true
 
 Lint/AssignmentInCondition:
   AllowSafeAssignment: false
@@ -230,3 +228,10 @@ Rails/FindBy:
   Enabled: true
   Include:
     - app/**/*.rb
+
+# RSpec
+RSpec/AlignLeftLetBrace:
+  Enabled: true
+
+RSpec/AlignRightLetBrace:
+  Enabled: false


### PR DESCRIPTION
Some of the styles in our rubocop config are much different than most seen in the ruby community; these are the least controversial changes.

[53949](https://app.clubhouse.io/dutchie/story/53949/rubocop-style-changes)

See [this PR](https://github.com/GetDutchie/Dutchie-Style/pull/4/files#diff-391be63d86ca0541cef3ee2c9302c75c391f294e4e8466af9c15d19137480fd1R40) for more discussion; these are basically the changes that had positive or neutral responses.