### PR TITLE
style(rubocop): change block style to be consistent

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -182,11 +182,6 @@ Style/RaiseArgs:
 Style/SignalException:
   EnforcedStyle: only_raise
 
-# { ... } for multi-line blocks is okay, follow Weirichs rule instead:
-# https://web.archive.org/web/20140221124509/http://onestepback.org/index.cgi/Tech/Ruby/BraceVsDoEnd.rdoc
-Style/BlockDelimiters:
-  Enabled: false
-
 # do / end blocks should be used for side effects,
 # methods that run a block for side effects and have
 # a useful return value are rare, assign the return


### PR DESCRIPTION
We currently allow any style of block, which leads to code such as:

```ruby
arr.select { |a|
  a == true
}
```

This occurs the most in specs:

```ruby
let(:customer) {
  create(:customer)
}
```

This is difficult to read because it is inconsistent. When enforced as line_count (default) it would read:

```ruby
arr.select { |a| a == true }

let(:customer) { create(:customer) }
```

And only breaks to do/end blocks when the code is too complex to fit on a single line:

```ruby
# I would argue these are not complex enough to be do/end blocks but they are at least consistent

arr.select do |a|
  a == true
end

let(:customer) do
  create(:customer)
end
```

More info in docs: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/BlockDelimiters