### PR TITLE
style(rubocop): reduce constraints on rspec memos and nesting

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -239,3 +239,9 @@ RSpec/AlignLeftLetBrace:
 
 RSpec/AlignRightLetBrace:
   Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/NestedGroups:
+  Max: 5


### PR DESCRIPTION
Change

RSpec/MultipleMemoizedHelpers:
  Max: 5 -> 10

RSpec/NestedGroups:
  Max: 3 -> 5

I just find these limits a bit restrictive in certain situations.