### PR TITLE
styles(rubocop): temporarily remove Rails/FindBy because of Mongoid

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -228,10 +228,14 @@ Lint/ConstantResolution:
 Rails/SaveBang:
   Enabled: false
 
-Rails/FindBy:
-  Enabled: true
-  Include:
-    - app/**/*.rb
+# Temporarily removing until Mongoid is no more...
+# Mongoid #find_by raises an exception if it can't be found, unlike AR #find_by, so .where().first is preferred
+# Rubocop can't tell the difference between the two
+#
+# Rails/FindBy:
+#   Enabled: true
+#   Include:
+#     - app/**/*.rb
 
 # RSpec
 RSpec/AlignLeftLetBrace:

--- a/default.yml
+++ b/default.yml
@@ -231,11 +231,10 @@ Rails/SaveBang:
 # Temporarily removing until Mongoid is no more...
 # Mongoid #find_by raises an exception if it can't be found, unlike AR #find_by, so .where().first is preferred
 # Rubocop can't tell the difference between the two
-#
-# Rails/FindBy:
-#   Enabled: true
-#   Include:
-#     - app/**/*.rb
+Rails/FindBy:
+  Enabled: false
+  Include:
+    - app/**/*.rb
 
 # RSpec
 RSpec/AlignLeftLetBrace:


### PR DESCRIPTION
# Summary

Turn off `Rails/FindBy`, with a comment.

Mongoid #find_by raises an exception if it can't be found, unlike AR #find_by, so `.where().first` is preferred
Rubocop can't tell the difference between the two

