### PR TITLE
styles(rubocop): enable layouts/classStructure

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -21,6 +21,10 @@ AllCops:
     - '*.yml'
     - '.pryrc'
 
+# https://docs.rubocop.org/rubocop/1.10/cops_layout.html#layoutclassstructure
+Layout/ClassStructure:
+  Enabled: true
+
 # Commonly used screens these days easily fit more than 80 characters.
 Layout/LineLength:
   Max: 120


### PR DESCRIPTION
Most ruby I've seen / written has a pretty similar structure, and I think it's nice to be consistent in it.

Here are the rubocop docs for it:
https://docs.rubocop.org/rubocop/1.10/cops_layout.html#layoutclassstructure

The community style guide describes it well; here is our guide (if we reject this change we can remove this from our guide): https://github.com/GetDutchie/Armageddon/wiki/Ruby-Style-Guide#consistent-classes