### PR TITLE
Reduced max class length

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -70,9 +70,9 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Max: 20
 
-# The guiding principle of classes is SRP, SRP can't be accurately measured by LoC
+# SRP classes should fit in 400 lines. Use inline disable comments in god models.
 Metrics/ClassLength:
-  Max: 1500
+  Max: 400
 
 # Check with yard instead.
 Style/DocumentationMethod:


### PR DESCRIPTION
1500 line classes should be the exception, not the rule. Let's identify line count which is not exceeded by 80% of classes and use that.