### PR TITLE
eng: Exclude factories for BlockLength

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -63,6 +63,8 @@ Layout/SpaceInsideHashLiteralBraces:
 
 # Exclude RSpec
 Metrics/BlockLength:
+  Exclude:
+    - "spec/factories/**/*.rb"
   ExcludedMethods: ['describe', 'context']
 
 # Too short methods lead to extraction of single-use methods, which can make


### PR DESCRIPTION
I am unsure why this seems to suddenly be complaining - maybe it always did and I didn't notice.

![Screen Shot 2021-09-27 at 6 15 34 PM](https://user-images.githubusercontent.com/323595/135006315-4df0ada7-7a23-44bf-830c-d2966bdaecc5.png)

This was tested locally and it removed the rubocop complaint