### PR TITLE
eng: Disable unsafe pluck rules | ENG-42244

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -263,7 +263,10 @@ Rails/FindBy:
   Include:
     - app/**/*.rb
 
-Rails/Pluck:
+Rails/PluckId:
+  Enabled: false
+
+Rails/PluckInWhere:
   Enabled: false
 
 # RSpec

--- a/lib/Dutchie/Style/version.rb
+++ b/lib/Dutchie/Style/version.rb
@@ -2,6 +2,6 @@
 
 module Dutchie
   module Style
-    VERSION = '2.0.4'
+    VERSION = '2.0.5'
   end
 end


### PR DESCRIPTION
Followup to https://github.com/GetDutchie/Dutchie-Style/pull/31

https://docs.rubocop.org/rubocop-rails/cops_rails.html#railspluckid
https://docs.rubocop.org/rubocop-rails/cops_rails.html#railspluckinwhere

The previous PR actually disabled the wrong rule, the unsafe rules that enforce usage of `pluck` are disabled in this PR. Both of the rules disabled in this PR produced broken code when I allowed Rubocop to autocorrect Arma. 