### PR TITLE
eng: Fix Gemfile.lock & bump version 2.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,35 @@
 PATH
   remote: .
   specs:
-    Dutchie-Style (1.0.10)
-      rubocop (~> 0.93.1)
+    Dutchie-Style (2.0.5)
+      rubocop (~> 1.30.1)
       rubocop-rails
       rubocop-rspec
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.2)
+    activesupport (7.0.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
-    ast (2.4.1)
-    concurrent-ruby (1.1.7)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.4.2)
-    i18n (1.8.5)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.2)
-    parallel (1.19.2)
-    parser (2.7.2.0)
+    minitest (5.18.1)
+    parallel (1.23.0)
+    parser (3.2.2.3)
       ast (~> 2.4.1)
-    rack (2.2.3)
-    rainbow (3.0.0)
+      racc
+    racc (1.7.1)
+    rack (3.0.8)
+    rainbow (3.1.1)
     rake (12.3.3)
-    regexp_parser (1.8.2)
-    rexml (3.2.4)
+    regexp_parser (2.8.1)
+    rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -42,30 +43,27 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (0.93.1)
+    rubocop (1.30.1)
       parallel (~> 1.10)
-      parser (>= 2.7.1.5)
+      parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8)
-      rexml
-      rubocop-ast (>= 0.6.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.18.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.7.1)
-      parser (>= 2.7.1.5)
-    rubocop-rails (2.6.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    rubocop-rails (2.14.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 0.82.0)
-    rubocop-rspec (1.44.1)
-      rubocop (~> 0.87)
-      rubocop-ast (>= 0.7.1)
-    ruby-progressbar (1.10.1)
-    thread_safe (0.3.6)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    unicode-display_width (1.7.0)
-    zeitwerk (2.4.0)
+      rubocop (>= 1.7.0, < 2.0)
+    rubocop-rspec (2.11.1)
+      rubocop (~> 1.19)
+    ruby-progressbar (1.13.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.4.2)
 
 PLATFORMS
   ruby
@@ -74,8 +72,8 @@ DEPENDENCIES
   Dutchie-Style!
   rake (~> 12.0)
   rspec (~> 3.0)
-  rubocop (~> 0.93.1)
-  rubocop-rails (~> 2.6.0)
+  rubocop (~> 1.30.1)
+  rubocop-rails (~> 2.14.2)
 
 BUNDLED WITH
-   2.2.27
+   2.3.4

--- a/lib/Dutchie/Style/version.rb
+++ b/lib/Dutchie/Style/version.rb
@@ -2,6 +2,6 @@
 
 module Dutchie
   module Style
-    VERSION = '2.0.5'
+    VERSION = '2.0.6'
   end
 end


### PR DESCRIPTION
`Gemfile.lock` got out of sync with `Gemfile`