### PR TITLE
Update rubocop gems

### DIFF
--- a/Dutchie-Style.gemspec
+++ b/Dutchie-Style.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1.30.1"
+  spec.add_dependency "rubocop", "~> 1.56.2"
   spec.add_dependency "rubocop-rspec"
   spec.add_dependency "rubocop-rails"
 end

--- a/Dutchie-Style.gemspec
+++ b/Dutchie-Style.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1.56.2"
+  spec.add_dependency "rubocop", "~> 1.56"
   spec.add_dependency "rubocop-rspec"
   spec.add_dependency "rubocop-rails"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
-gem "rubocop", "~> 1.30.1"
+gem "rubocop", "~> 1.56.2"
 gem "rubocop-rails", "~> 2.14.2"

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
-gem "rubocop", "~> 1.56.2"
-gem "rubocop-rails", "~> 2.14.2"
+gem "rubocop", "~> 1.56"
+gem "rubocop-rails", "~> 2.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    Dutchie-Style (2.0.6)
+    Dutchie-Style (2.0.7)
       rubocop (~> 1.56.2)
       rubocop-rails
       rubocop-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     Dutchie-Style (2.0.7)
-      rubocop (~> 1.56.2)
+      rubocop (~> 1.56)
       rubocop-rails
       rubocop-rspec
 
@@ -84,8 +84,8 @@ DEPENDENCIES
   Dutchie-Style!
   rake (~> 12.0)
   rspec (~> 3.0)
-  rubocop (~> 1.56.2)
-  rubocop-rails (~> 2.14.2)
+  rubocop (~> 1.56)
+  rubocop-rails (~> 2.14)
 
 BUNDLED WITH
    2.4.8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,28 @@
 PATH
   remote: .
   specs:
-    Dutchie-Style (2.0.5)
-      rubocop (~> 1.30.1)
+    Dutchie-Style (2.0.6)
+      rubocop (~> 1.56.2)
       rubocop-rails
       rubocop-rspec
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.6)
+    activesupport (7.0.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
+    base64 (0.1.1)
     concurrent-ruby (1.2.2)
     diff-lcs (1.4.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    minitest (5.18.1)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
+    minitest (5.20.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -29,7 +32,7 @@ GEM
     rainbow (3.1.1)
     rake (12.3.3)
     regexp_parser (2.8.1)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -43,23 +46,32 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    rubocop (1.30.1)
+    rubocop (1.56.2)
+      base64 (~> 0.1.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.18.0, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
+    rubocop-capybara (2.18.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.23.1)
+      rubocop (~> 1.33)
     rubocop-rails (2.14.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
-    rubocop-rspec (2.11.1)
-      rubocop (~> 1.19)
+    rubocop-rspec (2.23.2)
+      rubocop (~> 1.33)
+      rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -72,8 +84,8 @@ DEPENDENCIES
   Dutchie-Style!
   rake (~> 12.0)
   rspec (~> 3.0)
-  rubocop (~> 1.30.1)
+  rubocop (~> 1.56.2)
   rubocop-rails (~> 2.14.2)
 
 BUNDLED WITH
-   2.3.4
+   2.4.8

--- a/lib/Dutchie/Style/version.rb
+++ b/lib/Dutchie/Style/version.rb
@@ -2,6 +2,6 @@
 
 module Dutchie
   module Style
-    VERSION = '2.0.6'
+    VERSION = '2.0.7'
   end
 end


### PR DESCRIPTION
Rubocop 1.53 introduced a new `--lsp` flag that enables integration with IDEs for linting and formatting

https://docs.rubocop.org/rubocop/usage/lsp.html#neovim-nvim-lspconfig