### PR TITLE
eng: Target 3.1.4, correct deprecations, run rubocop on itself

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.1.4
   EnabledByDefault: true
   DisplayCopNames: true
   Exclude:
@@ -20,7 +20,6 @@ AllCops:
     - 'Guardfile'
     - '*.yml'
     - '.pryrc'
-
 
 # Capybara cops
 
@@ -80,7 +79,7 @@ Layout/SpaceInsideHashLiteralBraces:
 Metrics/BlockLength:
   Exclude:
     - "spec/factories/**/*.rb"
-  IgnoredMethods: ['describe', 'context']
+  AllowedMethods: ['describe', 'context']
 
 # Too short methods lead to extraction of single-use methods, which can make
 # the code easier to read (by naming things), but can also clutter the class
@@ -175,7 +174,7 @@ Style/MethodCallWithArgsParentheses:
   VersionAdded: '0.47'
   VersionChanged: '0.61'
   IgnoreMacros: true
-  IgnoredMethods: []
+  AllowedMethods: []
   AllowedPatterns: []
   IncludedMacros: []
   AllowParenthesesInMultilineCall: false
@@ -190,7 +189,7 @@ Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   StyleGuide: '#method-invocation-parens'
   Enabled: true
-  IgnoredMethods: []
+  AllowedMethods: []
   VersionAdded: '0.47'
   VersionChanged: '0.55'
 

--- a/Dutchie-Style.gemspec
+++ b/Dutchie-Style.gemspec
@@ -1,4 +1,6 @@
-require_relative 'lib/Dutchie/Style/version'
+# frozen_string_literal: true
+
+require_relative "lib/Dutchie/Style/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "Dutchie-Style"
@@ -6,12 +8,12 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Christopher Ostrowski"]
   spec.email         = ["chris@dutchie.com"]
 
-  spec.license = 'MIT'
+  spec.license = "MIT"
 
-  spec.summary       = %q{Rubocop Settings for all dutchie Ruby Apps}
-  spec.description   = %q{Rubocop Settings for all dutchie Ruby Apps}
+  spec.summary       = "Rubocop Settings for all dutchie Ruby Apps"
+  spec.description   = "Rubocop Settings for all dutchie Ruby Apps"
   spec.homepage      = "https://github.com/GetDutchie/Dutchie-Style"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.4")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/GetDutchie/Dutchie-Style"
@@ -19,14 +21,16 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files =
+    Dir.chdir(File.expand_path(__dir__)) do
+      `git ls-files -z`.split("\x0").reject {|f| f.match(%r{^(test|spec|features)/}) }
+    end
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 1.56"
-  spec.add_dependency "rubocop-rspec"
-  spec.add_dependency "rubocop-rails"
+  spec.add_dependency "rubocop-rails", "~> 2.21"
+  spec.add_dependency "rubocop-rspec", "~> 2.24"
+  spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/lib/Dutchie/Style.rb
+++ b/lib/Dutchie/Style.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "Dutchie/Style/version"
 
 module Dutchie

--- a/lib/Dutchie/Style/version.rb
+++ b/lib/Dutchie/Style/version.rb
@@ -2,6 +2,7 @@
 
 module Dutchie
   module Style
-    VERSION = '2.0.7'
+    VERSION = "2.0.8"
+    public_constant :VERSION
   end
 end


### PR DESCRIPTION
Targets Ruby 3.1.4, removes deprecated options for several cops, renames `default.yml` to `.rubocop.yml` and runs Rubocop on itself + corrections.