### PR TITLE
remove find_each cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -262,6 +262,10 @@ Rails/FindBy:
   Include:
     - app/**/*.rb
 
+# not a method in mongoid
+Rails/FindEach:
+  Enabled: false
+
 Rails/PluckId:
   Enabled: false
 


### PR DESCRIPTION
This cop https://www.rubydoc.info/gems/rubocop/0.41.2/RuboCop/Cop/Rails/FindEach might be good for activerecord models but this is not a method that exists on mongoid models and therefore breaks code.