### PR TITLE
enable OpenStructUse linting rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -211,6 +211,12 @@ Style/SignalException:
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
 
+  
+# OpenStruct shouldn't be used anymore due to performance
+# degradation on ruby 3.2+
+Style/OpenStructUse:
+  Enabled: true
+
 # Enforcing the names of variables? To single letter ones? Just no.
 Style/SingleLineBlockParams:
   Enabled: false


### PR DESCRIPTION
We need to get rid of any uses of OpenStruct in Armageddon in anticipation of ruby 3.2. and also discourage future use of OpenStruct.

See this PR: https://github.com/GetDutchie/Armageddon/pull/6960