### PR TITLE
Disable Rails/I18nLocaleTexts cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -280,6 +280,10 @@ Rails/PluckId:
 Rails/PluckInWhere:
   Enabled: false
 
+# Disable I18n locale texts cop
+Rails/I18nLocaleTexts:
+  Enabled: false
+
 # RSpec
 
 # Start context description without 'when', 'with', or 'without'.


### PR DESCRIPTION
This cop enforces using I18n keys for validation messages, but we don't use I18n translations consistently across the application. Disabling this cop allows direct string messages in validations.