### PR TITLE
eng: add LaunchDarkly cop spec and fix args destructuring bug ECOMM-8061

### DIFF
--- a/lib/rubocop/cop/dutchie/launchdarkly_defaults.rb
+++ b/lib/rubocop/cop/dutchie/launchdarkly_defaults.rb
@@ -144,7 +144,7 @@ module RuboCop
         # Armageddon pattern checks
 
         def check_flag_method(node)
-          flag_key, *args = dutchie_flag_call?(node)
+          flag_key, args = dutchie_flag_call?(node)
           return unless flag_key
 
           # Need at least one more argument after the key (the default value)
@@ -156,7 +156,7 @@ module RuboCop
         end
 
         def check_context_flag_method(node)
-          flag_key, *args = context_flag_call?(node)
+          flag_key, args = context_flag_call?(node)
           return unless flag_key
 
           return if has_default_kwarg?(args)
@@ -167,7 +167,7 @@ module RuboCop
         end
 
         def check_dispensary_flag_method(node)
-          flag_key, *args = dispensary_flag_call?(node)
+          flag_key, args = dispensary_flag_call?(node)
           return unless flag_key
 
           return if has_default_kwarg?(args)
@@ -178,7 +178,7 @@ module RuboCop
         end
 
         def check_enterprise_flag_method(node)
-          flag_key, *args = enterprise_flag_call?(node)
+          flag_key, args = enterprise_flag_call?(node)
           return unless flag_key
 
           return if has_default_kwarg?(args)
@@ -189,7 +189,7 @@ module RuboCop
         end
 
         def check_on_method(node)
-          flag_key, *args = on_call?(node)
+          flag_key, args = on_call?(node)
           return unless flag_key
 
           # on? accepts default: as keyword or as second positional argument
@@ -202,7 +202,7 @@ module RuboCop
         end
 
         def check_off_method(node)
-          flag_key, *args = off_call?(node)
+          flag_key, args = off_call?(node)
           return unless flag_key
 
           # off? accepts default: as keyword or as second positional argument
@@ -217,7 +217,7 @@ module RuboCop
         # MenuConnector pattern checks
 
         def check_variation_method(node)
-          flag_key, *args = variation_call?(node)
+          flag_key, args = variation_call?(node)
           return unless flag_key
 
           # variation(flag, context, default) - need at least 2 args after flag
@@ -238,7 +238,7 @@ module RuboCop
           # Don't check mock variation calls in test code
           return if in_test_file?(node)
 
-          flag_key, *args = mock_variation_call?(node)
+          flag_key, args = mock_variation_call?(node)
           return unless flag_key
 
           # Same logic as regular variation

--- a/spec/rubocop/cop/dutchie/launchdarkly_defaults_spec.rb
+++ b/spec/rubocop/cop/dutchie/launchdarkly_defaults_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe RuboCop::Cop::Dutchie::LaunchDarklyDefaults do
+  subject(:cop) { described_class.new }
+
+  describe "DutchieFeatureFlags.flag" do
+    context "when missing default value" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          DutchieFeatureFlags.flag("some.flag")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dutchie/LaunchDarklyDefaults: DutchieFeatureFlags.flag must have a default value as 2nd parameter
+        RUBY
+
+        expect_correction(<<~RUBY)
+          DutchieFeatureFlags.flag("some.flag", false)
+        RUBY
+      end
+    end
+
+    context "when default value is provided" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          DutchieFeatureFlags.flag("some.flag", false)
+        RUBY
+      end
+
+      it "accepts true as default" do
+        expect_no_offenses(<<~RUBY)
+          DutchieFeatureFlags.flag("some.flag", true)
+        RUBY
+      end
+
+      it "accepts additional arguments after default" do
+        expect_no_offenses(<<~RUBY)
+          DutchieFeatureFlags.flag("some.flag", false, custom_attributes)
+        RUBY
+      end
+    end
+  end
+
+  describe "DutchieFeatureFlags.context_flag" do
+    context "when missing default: keyword" do
+      it "registers an offense with no other arguments" do
+        expect_offense(<<~RUBY)
+          DutchieFeatureFlags.context_flag("some.flag")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dutchie/LaunchDarklyDefaults: DutchieFeatureFlags.context_flag must have a default: parameter
+        RUBY
+
+        expect_correction(<<~RUBY)
+          DutchieFeatureFlags.context_flag("some.flag", default: false)
+        RUBY
+      end
+
+      it "registers an offense with other keyword arguments" do
+        expect_offense(<<~RUBY)
+          DutchieFeatureFlags.context_flag("some.flag", dispensary_id: id)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dutchie/LaunchDarklyDefaults: DutchieFeatureFlags.context_flag must have a default: parameter
+        RUBY
+
+        expect_correction(<<~RUBY)
+          DutchieFeatureFlags.context_flag("some.flag", dispensary_id: id, default: false)
+        RUBY
+      end
+    end
+
+    context "when default: keyword is provided" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          DutchieFeatureFlags.context_flag("some.flag", default: false, dispensary_id: id)
+        RUBY
+      end
+
+      it "accepts default at any position in kwargs" do
+        expect_no_offenses(<<~RUBY)
+          DutchieFeatureFlags.context_flag("some.flag", dispensary_id: id, default: false)
+        RUBY
+      end
+    end
+  end
+
+  describe "DutchieFeatureFlags.dispensary_flag" do
+    context "when missing default: keyword" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          DutchieFeatureFlags.dispensary_flag("some.flag", dispensary_id: id)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dutchie/LaunchDarklyDefaults: DutchieFeatureFlags.dispensary_flag must have a default: parameter
+        RUBY
+
+        expect_correction(<<~RUBY)
+          DutchieFeatureFlags.dispensary_flag("some.flag", dispensary_id: id, default: false)
+        RUBY
+      end
+    end
+
+    context "when default: keyword is provided" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          DutchieFeatureFlags.dispensary_flag("some.flag", dispensary_id: id, default: false)
+        RUBY
+      end
+    end
+  end
+
+  describe "DutchieFeatureFlags.enterprise_flag" do
+    context "when missing default: keyword" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          DutchieFeatureFlags.enterprise_flag("some.flag", enterprise_id: id)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dutchie/LaunchDarklyDefaults: DutchieFeatureFlags.enterprise_flag must have a default: parameter
+        RUBY
+
+        expect_correction(<<~RUBY)
+          DutchieFeatureFlags.enterprise_flag("some.flag", enterprise_id: id, default: false)
+        RUBY
+      end
+    end
+
+    context "when default: keyword is provided" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          DutchieFeatureFlags.enterprise_flag("some.flag", enterprise_id: id, default: false)
+        RUBY
+      end
+    end
+  end
+
+  describe "DutchieFeatureFlags.on?" do
+    context "when missing default" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          DutchieFeatureFlags.on?("some.flag")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dutchie/LaunchDarklyDefaults: DutchieFeatureFlags.on? should have a default: parameter
+        RUBY
+
+        expect_correction(<<~RUBY)
+          DutchieFeatureFlags.on?("some.flag", default: false)
+        RUBY
+      end
+    end
+
+    context "when default is provided" do
+      it "does not register an offense with keyword arg" do
+        expect_no_offenses(<<~RUBY)
+          DutchieFeatureFlags.on?("some.flag", default: false)
+        RUBY
+      end
+
+      it "does not register an offense with positional arg" do
+        expect_no_offenses(<<~RUBY)
+          DutchieFeatureFlags.on?("some.flag", false)
+        RUBY
+      end
+    end
+  end
+
+  describe "DutchieFeatureFlags.off?" do
+    context "when missing default" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          DutchieFeatureFlags.off?("some.flag")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dutchie/LaunchDarklyDefaults: DutchieFeatureFlags.off? should have a default: parameter
+        RUBY
+
+        expect_correction(<<~RUBY)
+          DutchieFeatureFlags.off?("some.flag", default: false)
+        RUBY
+      end
+    end
+
+    context "when default is provided" do
+      it "does not register an offense with keyword arg" do
+        expect_no_offenses(<<~RUBY)
+          DutchieFeatureFlags.off?("some.flag", default: true)
+        RUBY
+      end
+
+      it "does not register an offense with positional arg" do
+        expect_no_offenses(<<~RUBY)
+          DutchieFeatureFlags.off?("some.flag", true)
+        RUBY
+      end
+    end
+  end
+
+  describe "edge cases" do
+    it "handles calls that are not DutchieFeatureFlags" do
+      expect_no_offenses(<<~RUBY)
+        SomeOtherClass.flag("some.flag")
+      RUBY
+    end
+
+    it "handles nested method calls" do
+      expect_offense(<<~RUBY)
+        if DutchieFeatureFlags.on?("feature.enabled")
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dutchie/LaunchDarklyDefaults: DutchieFeatureFlags.on? should have a default: parameter
+          do_something
+        end
+      RUBY
+    end
+
+    it "handles multiple flags in same file" do
+      expect_offense(<<~RUBY)
+        DutchieFeatureFlags.flag("first.flag")
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dutchie/LaunchDarklyDefaults: DutchieFeatureFlags.flag must have a default value as 2nd parameter
+        DutchieFeatureFlags.on?("second.flag")
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dutchie/LaunchDarklyDefaults: DutchieFeatureFlags.on? should have a default: parameter
+      RUBY
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rubocop"
+require "rubocop/rspec/support"
+require "dutchie-style"
+
+RSpec.configure do |config|
+  config.include RuboCop::RSpec::ExpectOffense
+end


### PR DESCRIPTION
## Summary
- Move the LaunchDarklyDefaults RuboCop cop spec from Armageddon into the Dutchie-Style gem where the cop now lives
- Fix a bug in the cop: `$...` pattern captures remaining args as an Array, but the code used splat (`*args`) which double-wrapped it, causing `hash_type?` to be called on an Array instead of an AST node
- The bug meant the cop silently failed to detect any violations for `context_flag`, `dispensary_flag`, `enterprise_flag`, `on?`, `off?`, and `flag` — it shipped in 2.1.0 but was effectively a no-op

## Test plan
- [x] All 21 RSpec examples pass locally
- [ ] Verify cop correctly flags missing defaults on real code after fix

## Related
- ECOMM-8061
- ECOMM-7031 (original cop implementation)
- ECOMM-7032 (Armageddon adoption)